### PR TITLE
Updates to adapt to changed INDRA Statement types

### DIFF
--- a/causal_paths/src/path_scoring.py
+++ b/causal_paths/src/path_scoring.py
@@ -155,11 +155,13 @@ class EdgeRanking:
                     "Ubiquitination",
                     "Deubiquitination",
                     "ActivityActivity",
-                    "RasGef"
+                    "Gef",
+                    "Gap"
                 ],
                 EdgeEnum.unspecified_activation_inhibition: [  # 2
                     "Activation",
-                    "Inhibition"
+                    "Inhibition",
+                    "GtpActivation"
                 ],
                 EdgeEnum.unspecified_state_control: [  # 3
                     "controls-state-change-of",
@@ -171,6 +173,8 @@ class EdgeRanking:
                 ],
                 EdgeEnum.transcriptional_control: [  # 5
                     "controls-expression-of",
+                    "IncreaseAmount",
+                    "DecreaseAmount",
                     "Acetylation",
                     "Deacetylation",
                     "Sumoylation",

--- a/config.ini
+++ b/config.ini
@@ -2,11 +2,11 @@
 TwoWayEdges: Complex,neighbor-of,interacts-with,in-complex-with
 
 [PreferenceSchedule]
-level1: controls-transport-of,controls-phosphorylation-of,Phosphorylation,Dephosphorylation,controls-transport-of-chemical,consumption-controled-by,controls-production-of,Ubiquitination,Deubiquitination,ActivityActivity,RasGef
-level2: Activation,Inhibition
+level1: controls-transport-of,controls-phosphorylation-of,Phosphorylation,Dephosphorylation,controls-transport-of-chemical,consumption-controled-by,controls-production-of,Ubiquitination,Deubiquitination,ActivityActivity,Gef,Gap
+level2: Activation,Inhibition,GtpActivation
 level3: controls-state-change-of,chemical-affects
 level4: reacts-with,used-to-produce
-level5: controls-expression-of,Acetylation,Deacetylation,Sumoylation,Ribosylation,Deribosylation
+level5: controls-expression-of,IncreaseAmount,DecreaseAmount,Acetylation,Deacetylation,Sumoylation,Ribosylation,Deribosylation
 level6: catalysis-precedes
 level7: in-complex-with,Complex
 level8: interacts-with


### PR DESCRIPTION
I made a few updates to adapt to INDRA Statement types that have changed and been extended. With this update it is now possible to query current "live" INDRA-assembled networks like 50e3dff7-133e-11e6-a039-06603eb7f303 (I tested this by running this service on localhost).
  